### PR TITLE
Deindented a task

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -28,7 +28,7 @@ The
     * unit tests
     * browserification
     * no minification, does not start server
- * `gulp watch`
+* `gulp watch`
     * starts server with live reload enabled
     * lints, unit tests, browserifies and live-reloads changes in browser
     * no minification


### PR DESCRIPTION
`gulp watch` was indented under `gulp fast` in the README